### PR TITLE
Update Flink to 1.19 and fix several bugs

### DIFF
--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/Benchmark.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/Benchmark.java
@@ -189,7 +189,8 @@ public class Benchmark {
 							cpuMetricReceiver,
 							monitorDelay,
 							monitorInterval,
-							monitorDuration);
+							monitorDuration,
+							workload.getEventsNum());
 			QueryRunner runner =
 					new QueryRunner(
 							queryName,

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/metric/BenchmarkMetric.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/metric/BenchmarkMetric.java
@@ -27,10 +27,12 @@ import java.util.TreeMap;
 
 public class BenchmarkMetric {
 	private final double tps;
+	private final int records;
 	private final double cpu;
 
-	public BenchmarkMetric(double tps, double cpu) {
+	public BenchmarkMetric(double tps, int records, double cpu) {
 		this.tps = tps;
+		this.records = records;
 		this.cpu = cpu;
 	}
 
@@ -40,6 +42,10 @@ public class BenchmarkMetric {
 
 	public String getPrettyTps() {
 		return formatLongValue((long) tps);
+	}
+
+	public int getRecords() {
+		return records;
 	}
 
 	public double getCpu() {

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/metric/FlinkRestClient.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/metric/FlinkRestClient.java
@@ -149,13 +149,17 @@ public class FlinkRestClient {
 	}
 
 	public String getTpsMetricName(String jobId, String vertexId) {
+		return getTpsMetricName(jobId, vertexId, "numRecordsOutPerSecond");
+	}
+
+	public String getTpsMetricName(String jobId, String vertexId, String name) {
 		String url = String.format("http://%s/jobs/%s/vertices/%s/subtasks/metrics", jmEndpoint, jobId, vertexId);
 		String response = executeAsString(url);
 		try {
 			ArrayNode arrayNode = (ArrayNode) NexmarkUtils.MAPPER.readTree(response);
 			for (JsonNode node : arrayNode) {
 				String metricName = node.get("id").asText();
-				if (metricName.startsWith("Source_") && metricName.endsWith(".numRecordsOutPerSecond")) {
+				if (metricName.startsWith("Source_") && metricName.endsWith("." + name)) {
 					return metricName;
 				}
 			}

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/metric/FlinkRestClient.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/metric/FlinkRestClient.java
@@ -116,7 +116,11 @@ public class FlinkRestClient {
 
 	public boolean isJobRunning() {
 		updateAllJobStatus();
-		return !isNullOrEmpty(lastJobId) && jobIds.get(lastJobId).equalsIgnoreCase("RUNNING");
+		String j = jobIds.get(lastJobId);
+		// Matei comment: This sometimes is "finished" before it even starts. I suspect that what happens is that
+		// the status hasn't been updated back to running yet.
+		//System.out.println(j);
+		return !isNullOrEmpty(lastJobId) && j.equalsIgnoreCase("RUNNING");
 	}
 
 	public boolean isJobCancellingOrFinished() {

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/metric/MetricReporter.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/metric/MetricReporter.java
@@ -239,7 +239,7 @@ public class MetricReporter {
 				// it's thread-safe to update metrics
 				metrics.add(metric);
 				// logging
-				String message = eventsNum == 0 ?
+				String message = eventsNum != 0 ?
 						String.format("Current Throughput=%s, Cores=%s (%s TMs)",
 								metric.getPrettyTps(), metric.getPrettyCpu(), tms) :
 						String.format("Current Cores=%s (%s TMs)", metric.getPrettyCpu(), tms);

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/metric/MetricReporter.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/metric/MetricReporter.java
@@ -135,19 +135,19 @@ public class MetricReporter {
 	}
 
 	private boolean jobIsFinished() {
-		if (metrics.size() <= 5) {
-			return false;
-		}
-		int lastPos = metrics.size() - 1;
-		BenchmarkMetric lastMetric = metrics.get(lastPos);
-		if (Double.compare(lastMetric.getTps(), 0.0) == 0) {
-			for (int i = 1;i < 5; i++) {
-				if (Double.compare(metrics.get(lastPos - i).getTps(), 0.0) != 0) {
-					return false;
-				}
-			}
-			return true;
-		}
+//		if (metrics.size() <= 5) {
+//			return false;
+//		}
+//		int lastPos = metrics.size() - 1;
+//		BenchmarkMetric lastMetric = metrics.get(lastPos);
+//		if (Double.compare(lastMetric.getTps(), 0.0) == 0) {
+//			for (int i = 1;i < 5; i++) {
+//				if (Double.compare(metrics.get(lastPos - i).getTps(), 0.0) != 0) {
+//					return false;
+//				}
+//			}
+//			return true;
+//		}
 		return false;
 	}
 

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/metric/MetricReporter.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/metric/MetricReporter.java
@@ -120,6 +120,8 @@ public class MetricReporter {
 		}
 	}
 
+	// Matei comment: This method doesn't work properly. Sometimes it says it's not running at the very start.
+	// More details in the FlinkRestClient method.
 	private boolean isJobRunning() {
 		return flinkRestClient.isJobRunning();
 	}

--- a/nexmark-flink/src/main/java/com/github/nexmark/flink/metric/tps/TpsMetric.java
+++ b/nexmark-flink/src/main/java/com/github/nexmark/flink/metric/tps/TpsMetric.java
@@ -73,7 +73,8 @@ public class TpsMetric {
 		final @Nullable @JsonProperty(FIELD_NAME_MIN) Double min,
 		final @Nullable @JsonProperty(FIELD_NAME_MAX) Double max,
 		final @Nullable @JsonProperty(FIELD_NAME_AVG) Double avg,
-		final @Nullable @JsonProperty(FIELD_NAME_SUM) Double sum) {
+		final @Nullable @JsonProperty(FIELD_NAME_SUM) Double sum,
+		final @Nullable @JsonProperty("skew") Double skew) {
 
 		this.id = requireNonNull(id, "id must not be null");
 		this.min = min;
@@ -82,8 +83,18 @@ public class TpsMetric {
 		this.sum = sum;
 	}
 
+	public TpsMetric(
+			String id,
+			Double min,
+			Double max,
+			Double avg,
+			Double sum) {
+
+		this(id, min, max, avg, sum, null);
+	}
+
 	public TpsMetric(final @JsonProperty(value = FIELD_NAME_ID, required = true) String id) {
-		this(id, null, null, null, null);
+		this(id, null, null, null, null, null);
 	}
 
 	@JsonIgnore

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ under the License.
     <version>0.2-SNAPSHOT</version>
 
     <properties>
-        <flink.version>1.15.0</flink.version>
+        <flink.version>1.19.1</flink.version>
         <slf4j.version>1.7.15</slf4j.version>
         <log4j.version>1.2.17</log4j.version>
         <java.version>1.8</java.version>


### PR DESCRIPTION
The following changes are made in this PR:

1. Flink is updated to 1.19.1
2. The metric reporter keeps track of how many events have been processed and stops when all of them are done processing
3. More information is printed about events processed and throughput during execution
4. Comments are added around a bug related to when the job finishing early.